### PR TITLE
[Issue-455]Fix zk startScript corner case handling

### DIFF
--- a/docker/bin/zookeeperStart.sh
+++ b/docker/bin/zookeeperStart.sh
@@ -109,7 +109,12 @@ if [[ "$ACTIVE_ENSEMBLE" == false ]]; then
 else
   # An ensemble exists, check to see if this node is already a member.
   if [[ "$ONDISK_MYID_CONFIG" == false || "$ONDISK_DYN_CONFIG" == false ]]; then
-    REGISTER_NODE=true
+    # for the first node, there is no ensemble to register.
+    if [[ $MYID -eq 1 ]]; then
+      REGISTER_NODE=false
+    else
+      REGISTER_NODE=true
+    fi
   else
     REGISTER_NODE=false
   fi


### PR DESCRIPTION

### Change log description
For first zk pod crash case, skip register node since it has no ensemble to register

### Purpose of the change

Fixes https://github.com/pravega/zookeeper-operator/issues/455


### What the code does

Check MyID when decide register node or not.

### How to verify it

Deploy zk cluster with the fix, pods should be started successfully. Restart zk pod also can be correctly handled.